### PR TITLE
Fix layout when parent is position:absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-split-view Changelog
 
+### 0.6.0
+
+* [ENHANCEMENT] Switched to latest ember-cli addon structure.
+
 ### 0.5.0
 
 * [ENHANCEMENT] Updated for ember-cli 0.1.1

--- a/addon/styles/split-view.css
+++ b/addon/styles/split-view.css
@@ -31,14 +31,13 @@
 .split-view .child {
 	position: absolute;
 	overflow: auto;
-}
-
-.split-view .child.vertical {
 	top: 0px;
 	bottom: 0px;
-}
-
-.split-view .child.horizontal {
 	left: 0px;
 	right: 0px;
+}
+
+.split-view .child.nested {
+	/* contains a nested split-view */
+	overflow: hidden;
 }

--- a/addon/styles/split-view.css
+++ b/addon/styles/split-view.css
@@ -28,17 +28,17 @@
 
 /* child pane */
 
-.split-view .split-child {
+.split-view .child {
 	position: absolute;
 	overflow: auto;
 }
 
-.split-view .split-child.vertical {
+.split-view .child.vertical {
 	top: 0px;
 	bottom: 0px;
 }
 
-.split-view .split-child.horizontal {
+.split-view .child.horizontal {
 	left: 0px;
 	right: 0px;
 }

--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  classNames: ['child'],
   classNameBindings: ['isDragging:dragging', 'isVertical:vertical:horizontal'],
   splitPercentage: Ember.computed.alias('parentView.splitPercentage'),
   sashWidthPercentage: Ember.computed.alias('parentView.sash.widthPercentage'),

--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -26,8 +26,10 @@ export default Ember.Component.extend({
     var s = "position: absolute;";
 
     if(this.get('isVertical')) {
+      // can't use height:100% as this wouldn't take account of padding and margins
       s += "top:0px;bottom:0px;";
     } else {
+      // can't use width:100% as this wouldn't take account of padding and margins
       s += "left:0px;right:0px;";
     }
 

--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -14,8 +14,9 @@ export default Ember.Component.extend({
   movableSide: null,
 
   didInsertElement: function() {
-    if(this.get('parentView').addSplit) {
-      this.get('parentView').addSplit(this);
+    var parent = this.get('parentView');
+    if(parent.addSplit) {
+      parent.addSplit(this);
     }
 
     Ember.run.scheduleOnce('afterRender', this, this.updateChildSplitView);

--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -26,9 +26,9 @@ export default Ember.Component.extend({
     var s = "position: absolute;";
 
     if(this.get('isVertical')) {
-      s += "height:100%;";
+      s += "top:0px;bottom:0px;";
     } else {
-      s += "width:100%;";
+      s += "left:0px;right:0px;";
     }
 
     if(this.get('fixedSide')) {

--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   classNames: ['child'],
-  classNameBindings: ['isDragging:dragging', 'isVertical:vertical:horizontal'],
+  classNameBindings: ['isDragging:dragging', 'isVertical:vertical:horizontal', 'childSplitView:nested'],
   splitPercentage: Ember.computed.alias('parentView.splitPercentage'),
   sashWidthPercentage: Ember.computed.alias('parentView.sash.widthPercentage'),
   isVertical: Ember.computed.alias('parentView.isVertical'),
@@ -18,8 +18,6 @@ export default Ember.Component.extend({
     if(parent.addSplit) {
       parent.addSplit(this);
     }
-
-    Ember.run.scheduleOnce('afterRender', this, this.updateChildSplitView);
   },
 
   willDestroyElement: function() {
@@ -29,16 +27,12 @@ export default Ember.Component.extend({
   style: function() {
     var s = "";
 
-    if(this.get('fixedSide')) {
-      s += this.get('fixedSide') + ":0px;"
-    }
-
     if(this.get('movableSide')) {
       s += this.get('movableSide') + ":" + this.get('movablePercent') + "%";
     }
 
     return s;
-  }.property('fixedSide', 'movableSide', 'movablePercent'),
+  }.property('movableSide', 'movablePercent'),
 
   movablePercent: function() {
     if(!this.get('movableSide')) {
@@ -53,11 +47,15 @@ export default Ember.Component.extend({
   }.property('sashWidthPercentage', 'splitPercentage', 'movableSide'),
 
   updateChildSplitView: function() {
-    var childSplit = this.get('childSplitView');
 
-    if(childSplit) {
-      childSplit.set('width', this.$().width());
-      childSplit.set('height', this.$().height());
-    }
+    // must run afterRender so that the size has updated
+    Ember.run.scheduleOnce('afterRender', this, function() {
+      var childSplit = this.get('childSplitView');
+
+      if(childSplit) {
+        childSplit.set('width', this.$().width());
+        childSplit.set('height', this.$().height());
+      }
+    });
   }.observes('childSplitView', 'movablePercent')
 });

--- a/app/components/split-sash.js
+++ b/app/components/split-sash.js
@@ -46,9 +46,11 @@ export default Ember.Component.extend({
     s += "%; ";
 
     if(this.get('isVertical')) {
-      s += "width:" + this.get('width') + "px; height:100%; cursor:ew-resize;";
+      // can't use height: 100% as that doesn't allow for padding, margins and borders
+      s += "width:" + this.get('width') + "px; top:0px;bottom:0px; cursor:ew-resize;";
     } else {
-      s += "width:100%;" + "height:" + this.get('width') + "px; cursor:ns-resize;";
+      // can't use width: 100% as that doesn't allow for padding, margins and borders
+      s += "left:0px;right:0px;" + "height:" + this.get('width') + "px; cursor:ns-resize;";
     }
 
     if(this.get('isDragging')) {

--- a/app/components/split-sash.js
+++ b/app/components/split-sash.js
@@ -12,6 +12,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   width: 6,
   widthPercentage: null,
+  classNames: ['sash'],
   classNameBindings: ['isDragging:dragging', 'isVertical:vertical:horizontal'],
   isVertical: Ember.computed.alias('parentView.isVertical'),
   isDragging: Ember.computed.alias('parentView.isDragging'),

--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -70,10 +70,10 @@ export default Ember.Component.extend({
     }
 
     Ember.run.scheduleOnce('afterRender', this, function() {
+      // must do this in afterRender so that the parent has calculated its width and height
       if(!(parentView instanceof SplitChild)) {
-        // must do this in afterRender so that the parent has calculated its width and height
         this.set('width', this.$().width());
-        this.set('height', this.$().height());      
+        this.set('height', this.$().height());    
       }      
     });
   },

--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -67,6 +67,7 @@ export default Ember.Component.extend({
     Ember.run.schedule('afterRender', function() {
       var parentView = self.get('parentView');
       if(!(parentView instanceof SplitChild)) {
+        // must do this in afterRender so that the parent has calculated its width and height
         self.set('width', self.$().width());
         self.set('height', self.$().height());      
       }

--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -54,6 +54,7 @@ export default Ember.Component.extend({
   splits: null,
   isDragging: false,
   attributeBindings: ['style'],
+  classNames: ['split-view'],
   classNameBindings: ['isDragging:dragging', 'isVertical:vertical:horizontal'],
 
   init: function() {

--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -63,16 +63,18 @@ export default Ember.Component.extend({
   },
 
   didInsertElement: function() {
-    this.set('parentView.childSplitView', this);
-    var self = this;
+    var parentView = this.get('parentView');
 
-    Ember.run.schedule('afterRender', function() {
-      var parentView = self.get('parentView');
+    if(parentView instanceof SplitChild) {
+      parentView.set('childSplitView', this);
+    }
+
+    Ember.run.scheduleOnce('afterRender', this, function() {
       if(!(parentView instanceof SplitChild)) {
         // must do this in afterRender so that the parent has calculated its width and height
-        self.set('width', self.$().width());
-        self.set('height', self.$().height());      
-      }
+        this.set('width', this.$().width());
+        this.set('height', this.$().height());      
+      }      
     });
   },
 

--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -62,12 +62,15 @@ export default Ember.Component.extend({
 
   didInsertElement: function() {
     this.set('parentView.childSplitView', this);
-    var parentView = this.get('parentView');
+    var self = this;
 
-    if(!(parentView instanceof SplitChild)) {
-      this.set('width', this.$().width());
-      this.set('height', this.$().height());      
-    }
+    Ember.run.schedule('afterRender', function() {
+      var parentView = self.get('parentView');
+      if(!(parentView instanceof SplitChild)) {
+        self.set('width', self.$().width());
+        self.set('height', self.$().height());      
+      }
+    });
   },
 
   addSplit: function(split) {


### PR DESCRIPTION
Moved more styling into css so app developer can override. Only dragged position is now inline.

Added css classes:

split-view, child, sash (self explanatory)
vertical, horizontal - classes on view,child and sash which say whether this level's sash is vertical or horizontal
nested - class on a child if it contains a nested split-view (css hides the scroll bars in this case)
dragging - class on view, child and sash when sash is being dragged, so app developer can decorate them