### PR TITLE
Having a high z-index is a bad practice

### DIFF
--- a/addon/styles/split-view.css
+++ b/addon/styles/split-view.css
@@ -4,7 +4,7 @@
 
 .split-view .sash {
 	background-color: transparent;
-	z-index: 9999;
+	z-index: 10;
 	position: absolute;
 	opacity: 0.1;
 }


### PR DESCRIPTION
Hi, this z-index is bad. It's making the sash appear over bootstrap dialogs. I would say get the project should make it lower like 1 or 2, but I guess 10 works in most cases.