### PR TITLE
Use SafeString for styles to avoid Ember warning about binding styles

### DIFF
--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
       s += this.get('movableSide') + ":" + this.get('movablePercent') + "%";
     }
 
-    return s;
+    return s.htmlSafe();
   }.property('movableSide', 'movablePercent'),
 
   movablePercent: function() {

--- a/app/components/split-sash.js
+++ b/app/components/split-sash.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
       s += "height:" + this.get('width') + "px;";
     }
 
-    return s;
+    return s.htmlSafe();
    }.property('splitPercentage', 'widthPercentage', 'isVertical', 'width'),
 
   updateWidthPercentage: function() {

--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -101,7 +101,7 @@ export default Ember.Component.extend({
       s += "height:" + this.get('height') + "px; ";
     }
 
-    return s;
+    return s.htmlSafe();
   }.property('width', 'height'),
 
   updateOrientation: function() {


### PR DESCRIPTION
Fixes issue https://github.com/BryanHunt/ember-split-view/issues/21