### PR TITLE
Stop dragging when we leave the split view

### DIFF
--- a/app/components/split-view.js
+++ b/app/components/split-view.js
@@ -150,6 +150,10 @@ export default Ember.Component.extend({
     this.set('isDragging', false);
   },
 
+  mouseLeave: function() {
+    this.set('isDragging', false);
+  },
+
   mouseMove: function(event) {
     if(!this.get('isDragging')) {
       return;


### PR DESCRIPTION
Currently if you click on a sash and then move the cursor out of the split view, upon re-entering the split view the sash is "stuck" to the cursor. This PR solves that.