### PR TITLE
Allow programmatic collapsing of panes

### DIFF
--- a/app/components/split-child.js
+++ b/app/components/split-child.js
@@ -19,6 +19,14 @@ export default Ember.Component.extend({
   fixedSide: null,
   movableSide: null,
 
+  init: function() {
+    this._super();
+
+    Ember.run.schedule('afterRender', this, function() {
+      this.set('register-as', this); // register-as is a new property
+    });
+  },
+
   didInsertElement: function() {
     var parent = this.get('parentView');
 
@@ -68,5 +76,14 @@ export default Ember.Component.extend({
         childSplit.set('height', this.$().height());
       }
     });
-  })
+  }),
+
+  collapse: function() {
+    if(this.get('movableSide') === "left" || this.get('movableSide') === "top") {
+      this.set('splitPercentage', 100);
+    } else {
+      this.set('splitPercentage', 0);
+    }
+    this.get('parentView').constrainSplit();
+  }
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,5 +7,6 @@ export default Ember.Controller.extend({
     Ember.Object.create({ title: "Vertical Composite", content: 'verticalComposite'}),
     Ember.Object.create({ title: "Horizontal Composite", content: 'horizontalComposite'}),
     Ember.Object.create({ title: "Composite", content: 'composite'}),
+    Ember.Object.create({ title: "Collapsible Panes", content: 'collapsiblePanes'}),
   ])
 });

--- a/tests/dummy/app/controllers/collapsible.js
+++ b/tests/dummy/app/controllers/collapsible.js
@@ -1,0 +1,10 @@
+export default Ember.Controller.extend({
+  actions: {
+    collapseLeft: function() {
+      this.get('leftChild').collapse();
+    },
+    collapseRight: function() {
+      this.get('rightChild').collapse();
+    }
+  }
+});

--- a/tests/dummy/app/controllers/collapsible.js
+++ b/tests/dummy/app/controllers/collapsible.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   actions: {
     collapseLeft: function() {

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,4 +11,5 @@ export default Router.map(function() {
   this.route('verticalComposite');
   this.route('horizontalComposite');
   this.route('composite');
+  this.route('collapsible');
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -10,6 +10,7 @@
     {{#link-to "verticalComposite" class="toolbar-item"}}Vertical Composite{{/link-to}}
     {{#link-to "horizontalComposite" class="toolbar-item"}}Horizontal Composite{{/link-to}}
     {{#link-to "composite" class="toolbar-item"}}Composite{{/link-to}}
+    {{#link-to "collapsible" class="toolbar-item"}}Collapsible{{/link-to}}
   </div>
 {{/paper-toolbar}}
 

--- a/tests/dummy/app/templates/collapsible.hbs
+++ b/tests/dummy/app/templates/collapsible.hbs
@@ -1,0 +1,13 @@
+<div class="demo-tab">
+  {{#split-view isVertical=true class="splitViewVertical"}}
+    {{#split-child class="border" register-as=leftChild}}
+      <button {{action 'collapseLeft'}}> Collapse Left </button>
+      {{partial "ring"}}
+    {{/split-child}}
+    {{split-sash}}
+    {{#split-child class="border" register-as=rightChild}}
+      <button {{action 'collapseRight'}}> Collapse Right </button>
+      {{partial "yoda"}}
+    {{/split-child}}
+  {{/split-view}}
+</div>


### PR DESCRIPTION
Wasn't sure about the best approach to this but heres a crack at it. I thought I'd submit a PR before documenting it to check the API/ implementation are sensible.

For each spit-child you can specify a register-as property. After the split child is created and rendered it sets whatever this property is to a reference to the split child. This means that you can access the split-child from a parent controller.

Now you have access to the split child from the parent controller you can call splitChild.collapse() from the parent controller.

Example in the dummy app.

One further change that I think should be made is to make it such that when you collapse a pane it ignores the panes min width property or at least allows you to specify if it is respected. I expect most use cases will want to collapse a pane entirely rather than have it only go down to the min width.