### PR TITLE
[NOT MEANT TO MERGE] Cast splitPosition to numeric value while calculating anchorOffset

### DIFF
--- a/addon/components/split-child.js
+++ b/addon/components/split-child.js
@@ -89,14 +89,16 @@ export default Ember.Component.extend({
     var sashWidth = this.get('sashWidth');
     var splitPosition = this.get('splitPosition');
     if(anchorSide === "left" || anchorSide === "top") {
-      return splitPosition + sashWidth / 2;
+      // HACK: splitPosition is sometimes a string... cast by multiplying by 1
+      return (splitPosition * 1) + sashWidth / 2;
     } else {
       var parentSize = this.get('parentSize');
       if (!parentSize)
       {
         return 0;
       }
-      return parentSize - splitPosition + sashWidth / 2;
+      // HACK: splitPosition is sometimes a string... cast by multiplying by 1
+      return parentSize - (splitPosition * 1) + sashWidth / 2;
     }
   }),
 
@@ -134,10 +136,10 @@ export default Ember.Component.extend({
     var cssInt = function(name) {
       return parseInt(this.css(name));
     }.bind(element);
-    
+
     if(this.get('isVertical')) {
-      return cssInt("min-width") + cssInt("padding-left") + cssInt("padding-right") + 
-                                  cssInt("border-left")  + cssInt("border-right") + 
+      return cssInt("min-width") + cssInt("padding-left") + cssInt("padding-right") +
+                                  cssInt("border-left")  + cssInt("border-right") +
                                   cssInt("margin-left")  + cssInt("margin-right") +
                                   this.get('sashWidth') / 2;
     } else {


### PR DESCRIPTION
##### DISCLAIMER

This commit is not a proper solution to the underlying bug. It's a minimal workaround for one use case in a consuming app. 

##### Underlying Issue

I am using a horizontal split view and noticed that the bottom child disappeared when I dragged the sash up 'too high'. While debugging, I realized that `splitPosition` was arriving as a string sometimes.

```javascript
// splitPosition was '200'
// sashWidth was 6
// so this line was returning 2003 instead of 203
return splitPosition + sashWidth / 2;
```

So the bottom child view received `top: 2003px`, which sent it clear off the bottom of the screen.