### PR TITLE
Scope all class names to avoid use of generic names

### DIFF
--- a/addon/components/split-child.js
+++ b/addon/components/split-child.js
@@ -5,7 +5,7 @@ const { computed, observer } = Ember;
 
 export default Ember.Component.extend({
   layout: splitChildLayout,
-  classNames: ['child'],
+  classNames: ['split-view-child'],
   classNameBindings: [
     'parent.isDragging:dragging',
     'parent.isVertical:vertical:horizontal',

--- a/addon/components/split-sash.js
+++ b/addon/components/split-sash.js
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
   width: 6,
   widthPercentage: null,
 
-  classNames: ['sash'],
+  classNames: ['split-view-sash'],
   classNameBindings: ['parent.isDragging:dragging', 'parent.isVertical:vertical:horizontal'],
 
   didInsertElement() {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -55,7 +55,7 @@ body > .ember-view {
   right: 0;
 }
 
-.child {
+.split-view-child {
   padding: 10px;
   overflow: hidden;
   min-width: 100px;

--- a/vendor/ember-split-view/styles/split-view.css
+++ b/vendor/ember-split-view/styles/split-view.css
@@ -2,25 +2,25 @@
 
 /* sash */
 
-.split-view .sash {
+.split-view .split-view-sash {
 	background-color: transparent;
 	z-index: 10;
 	position: absolute;
 	opacity: 0.1;
 }
 
-.split-view .sash.dragging, 
-.split-view .sash:hover {
+.split-view .split-view-sash.dragging,
+.split-view .splib-view-sash:hover {
 	background-color: black;
 }
 
-.split-view .sash.vertical {
+.split-view .split-view-sash.vertical {
 	top: 0px;
 	bottom: 0px;
 	cursor: ew-resize;
 }
 
-.split-view .sash.horizontal {
+.split-view .split-view-sash.horizontal {
 	left: 0px;
 	right: 0px;
 	cursor: ns-resize;
@@ -28,7 +28,7 @@
 
 /* child pane */
 
-.split-view .child {
+.split-view .split-view-child {
 	position: absolute;
 	overflow: auto;
 	top: 0px;
@@ -37,7 +37,7 @@
 	right: 0px;
 }
 
-.split-view .child .split-view {
+.split-view .split-view-child .split-view {
 	position: absolute;
     left: 0;
     right: 0;
@@ -45,7 +45,7 @@
     bottom: 0;
 }
 
-.split-view .child.nested {
+.split-view .split-view-child.nested {
 	/* contains a nested split-view */
 	overflow: hidden;
 	padding: 0px;


### PR DESCRIPTION
Hi, Bryan --

Of the three split pane ember addons I found, yours is the only one that seems to work with modern Ember. Do you mind if I contribute some changes? I have a project that I'll point to my fork for the time being.

Steve