### PR TITLE
Remove pin to ember-cli-sass 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
-    "ember-cli-sass": "4.0.1"
+    "ember-cli-sass": "^4.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
ember-cli-sass has updated to `6.1.2`.  As I'm upgrading an app (and updating that add-on) I'm ending up with two versions of `ember-cli-sass` (and worse, two versions of `node-sass` 😀 ) Can we let this dependency float?